### PR TITLE
Fix boost::bind compilation with Boost 1.58

### DIFF
--- a/src/tileset-fat.cpp
+++ b/src/tileset-fat.cpp
@@ -350,7 +350,7 @@ stream::inout_sptr Tileset_FAT::openStream(const EntryPtr& id)
 	FATEntryPtr pFAT = boost::dynamic_pointer_cast<FATEntry>(id);
 	assert(pFAT);
 
-	stream::fn_truncate fnTruncate = boost::bind<void>(&Tileset_FAT::resize, this, id, _1);
+	stream::fn_truncate fnTruncate = boost::bind(&Tileset_FAT::resize, this, id, _1);
 
 	stream::sub_sptr sub(new stream::sub);
 	sub->open(

--- a/src/tilesetFromList.cpp
+++ b/src/tilesetFromList.cpp
@@ -52,7 +52,7 @@ TilesetFromList::TilesetFromList(const TileList& tileList, ImagePtr img,
 		fat->index = i;
 		this->items.push_back(ep);
 	}
-	this->fnImageChanged = boost::bind<void>(&TilesetFromList::imageChanged, this);
+	this->fnImageChanged = boost::bind(&TilesetFromList::imageChanged, this);
 }
 
 TilesetFromList::~TilesetFromList()

--- a/src/tls-czone.cpp
+++ b/src/tls-czone.cpp
@@ -188,7 +188,7 @@ TilesetPtr Tileset_CZone::openTileset(const EntryPtr& id)
 {
 	Tileset_FAT::FATEntryPtr pFAT = boost::dynamic_pointer_cast<Tileset_FAT::FATEntry>(id);
 	assert(pFAT);
-	stream::fn_truncate fnTruncate = boost::bind<void>(&Tileset_CZone::resize, this, id, _1);
+	stream::fn_truncate fnTruncate = boost::bind(&Tileset_CZone::resize, this, id, _1);
 	stream::sub_sptr sub(new stream::sub);
 	sub->open(this->data, pFAT->offset + pFAT->lenHeader, pFAT->size, fnTruncate);
 	TilesetPtr tileset;

--- a/src/tls-img.cpp
+++ b/src/tls-img.cpp
@@ -48,7 +48,7 @@ Image_TilesetFrom::Image_TilesetFrom(ImagePtr img, unsigned int tileWidth,
 		fat->index = i;
 		this->items.push_back(ep);
 	}
-	this->fnImageChanged = boost::bind<void>(&Image_TilesetFrom::imageChanged, this);
+	this->fnImageChanged = boost::bind(&Image_TilesetFrom::imageChanged, this);
 }
 
 Image_TilesetFrom::~Image_TilesetFrom()


### PR DESCRIPTION
For some reason, Boost 1.58 doesn't like boost::bind<type>() anymore.
boost::bind(), without explicitly stating the template specialization,
works, though, and has always worked with older Boost version as well.